### PR TITLE
Delete transactions_controller.rb

### DIFF
--- a/structured-finance-backend/app/controllers/transactions_controller.rb
+++ b/structured-finance-backend/app/controllers/transactions_controller.rb
@@ -1,2 +1,0 @@
-class API::V1::TransactionsController < ApplicationController
-end


### PR DESCRIPTION
Renamed Transaction model to Deal because of ActiveRecord conflict with ActiveRecord method transaction.