### PR TITLE
Delete transaction.rb

### DIFF
--- a/structured-finance-backend/app/models/transaction.rb
+++ b/structured-finance-backend/app/models/transaction.rb
@@ -1,3 +1,0 @@
-class Transaction < ApplicationRecord
-    has_many :reports
-end


### PR DESCRIPTION
Renamed Transaction model to Deal because of ActiveRecord conflict with ActiveRecord method transaction.